### PR TITLE
Reintroducing advent ID after bad merge

### DIFF
--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -69,7 +69,8 @@ Delta = Optional[Seconds]
 # TODO: make these types more specific with TypedDict and Literal when possible.
 
 class Member:
-    def __init__(self, name: str, local: int, stars: int, global_: int) -> None:
+    def __init__(self, id: int, name: str, local: int, stars: int, global_: int) -> None:
+        self.id = id
         self.name = name
         self.local = local
         self.stars = stars


### PR DESCRIPTION
This restores the ID that was introduced as part of @TomCranitch's updated advent code but had a bad merge break it.