### PR TITLE
No more yelling at links (plus a little docstring fix)

### DIFF
--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -20,7 +20,7 @@ class Yelling(commands.Cog):
 
         # ignore emoji and links
         text = re.sub(r":[\w\-\+\_']+:", lambda m: m.group(0).upper(), msg.content, flags=re.UNICODE)
-        text = re.sub(r"(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w\.-]*)", lambda m: m.group(0).upper(), text, flags=re.UNICODE)
+        text = re.sub(r"(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]+)(((%[\da-f]{2})|[\/\w\.-])*)", lambda m: m.group(0).upper(), text, flags=re.UNICODE)
         text = text.replace("&gt;", ">").replace("&lt;", "<").replace("&amp;", "&")
 
         response = choice(["WHAT’S THAT‽",

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -13,13 +13,14 @@ class Yelling(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, msg: discord.Message):
-        """ Detects if a message is sent in #jobs_bulletin and sends notification to channel and author. """
+        """ Detects if a user is not yelling in #yelling and responds accordingly """
         if not self.bot.user or not isinstance(msg.channel, discord.TextChannel) or \
                 msg.author.id == self.bot.user.id or msg.channel.name != self.CHANNEL_NAME:
             return
 
-        # ignore emoji
+        # ignore emoji and links
         text = re.sub(r":[\w\-\+\_']+:", lambda m: m.group(0).upper(), msg.content, flags=re.UNICODE)
+        text = re.sub(r"(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w\.-]*)", lambda m: m.group(0).upper(), text, flags=re.UNICODE)
         text = text.replace("&gt;", ">").replace("&lt;", "<").replace("&amp;", "&")
 
         response = choice(["WHAT’S THAT‽",


### PR DESCRIPTION
Docstring was incorrect for function

Regex added to prevent links from being yelled at in the same method as the current method for ignoring emojis.

I'm not a regex pro so I stole the expression from: https://stackoverflow.com/questions/21932615/regular-expression-for-remove-link 