### PR TITLE
Make whatweekisit timezone-aware

### DIFF
--- a/uqcsbot/whatweekisit.py
+++ b/uqcsbot/whatweekisit.py
@@ -2,6 +2,7 @@ import discord
 from discord import app_commands
 import requests
 from typing import NamedTuple, List, Tuple, Optional
+from zoneinfo import ZoneInfo
 from datetime import datetime, timedelta
 from math import ceil
 
@@ -36,7 +37,7 @@ def string_to_date(date: str) -> datetime:
         Returns:
             Stringified date
     """
-    return datetime.strptime(date, DATE_FORMAT)
+    return datetime.strptime(date, DATE_FORMAT).replace(tzinfo=ZoneInfo("Australia/Brisbane"))
 
 
 def get_semester_times(markup: str) -> List[Semester]:
@@ -125,7 +126,7 @@ class WhatWeekIsIt(commands.Cog):
         await interaction.response.defer(thinking=True)
 
         if date == None:
-            check_date = datetime.now()
+            check_date = datetime.now(tz=ZoneInfo("Australia/Brisbane"))
         else:
             try:
                 check_date = string_to_date(date)


### PR DESCRIPTION
I thought this would be 2 lines, but it's actually 3. Please forgive me.

This makes the `/whatweekisit` command say today's date, rather than yesterday's, when run between the hours of 
00:00 and 10:00 (Brisbane time).
