### PR TITLE
Added description of testing to README and fixed test_whatweeksiti.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,16 @@ docker-compose down
 
 ## Testing
 
-Coming soon.
+Tests are stored in the `tests` folder and the tests for each file are prefixed with `test_`. Each test should `import pytest` and import the relevant functions from the given part of `uqcsbot`. Tests should mainly focus on cog-specific behaviours and should avoid interacting with discord (say, to detect if a message was sent; see issue [#2](https://github.com/UQComputingSociety/uqcsbot-discord/issues/2#issuecomment-1498967689)).
+
+To run all tests:
+```
+poetry run pytest
+```
+To run a particular test, say `test_whatweekisit.py`, run:
+```
+poetry run pytest tests\test_whatweekisit.py
+```
 
 ## Development Resources
 

--- a/tests/test_whatweekisit.py
+++ b/tests/test_whatweekisit.py
@@ -18,7 +18,7 @@ FIXTURE_DIR = os.path.join(
 
 @pytest.mark.datafiles(os.path.join(FIXTURE_DIR, "test_whatweekisit.html"))
 def test_get_semester_times_from_file(datafiles):
-    with open(os.path.join(datafiles, "test_whatweekisit.html"), "r") as f:
+    with open(os.path.join(datafiles, "test_whatweekisit.html"), "r", encoding='utf-8') as f:
         hardcoded_file = f.read()
 
     # We can manually look at the HTML document to see if this is accurate
@@ -38,7 +38,7 @@ def test_get_semester_times_from_file(datafiles):
 
 @pytest.mark.datafiles(os.path.join(FIXTURE_DIR, "test_whatweekisit.html"))
 def test_get_semester_week_from_file(datafiles):
-    with open(os.path.join(datafiles, "test_whatweekisit.html"), "r") as f:
+    with open(os.path.join(datafiles, "test_whatweekisit.html"), "r", encoding='utf-8') as f:
         hardcoded_file = f.read()
 
     # Get semesters so we can then get the week from it


### PR DESCRIPTION
A bit of a 2-part pull request, but both are quite small and related.
README now has a brief description of what is involved to write and run the (currently limited) tests of the bot. Feel free to adjust this as needed, as I'm not great at writing.
Corrected the `test_whatweeksiti.py` to pass. I didn't really change the test case, just read the given input file as unicode, as the non-breaking spaces for the empty table cells were being read as 2 non-space ASCII characters.