### PR TITLE
Modified uptime to also work in test server

### DIFF
--- a/uqcsbot/uptime.py
+++ b/uqcsbot/uptime.py
@@ -11,21 +11,19 @@ from uqcsbot.bot import UQCSBot
 
 
 class UpTime(commands.Cog):
-    # Checks for an Azure specific environment variable, if it exists we're running as prod.
-    CHANNEL_ID = 836243768411160606 if os.environ.get("WEBSITE_SITE_NAME") != None \
-        else 1041708952066461716
+    CHANNEL_NAME = "bot-testing"
 
     def __init__(self, bot: UQCSBot):
         self.bot = bot
 
     @commands.Cog.listener()
     async def on_ready(self):
-        channel = self.bot.get_channel(self.CHANNEL_ID)
+        channel = discord.utils.get(self.bot.get_all_channels(), name=self.CHANNEL_NAME)
 
         if channel != None:
             await channel.send("I have rebooted!")
         else:
-            logging.warning(f"bot-testing channel not found {self.CHANNEL_ID}") 
+            logging.warning(f"#{self.CHANNEL_NAME} not found") 
 
     @app_commands.command()
     async def uptime(self, interaction: discord.Interaction):

--- a/uqcsbot/uptime.py
+++ b/uqcsbot/uptime.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+import os
 
 import discord
 from discord import app_commands
@@ -10,7 +11,9 @@ from uqcsbot.bot import UQCSBot
 
 
 class UpTime(commands.Cog):
-    CHANNEL_ID = 836243768411160606
+    # Checks for an Azure specific environment variable, if it exists we're running as prod.
+    CHANNEL_ID = 836243768411160606 if os.environ.get("WEBSITE_SITE_NAME") != None \
+        else 1041708952066461716
 
     def __init__(self, bot: UQCSBot):
         self.bot = bot


### PR DESCRIPTION
Uptime now finds #bot-testing by using a different channel ID depending on a Azure specific environment variable. This approach is the same as used in `bot.py`, so should have no issues. This should (hopefully) not affect production and provide reboot messages to the testing server.