### PR TITLE
Member count

### DIFF
--- a/uqcsbot/member_counter.py
+++ b/uqcsbot/member_counter.py
@@ -48,7 +48,7 @@ class MemberCounter(commands.Cog):
             for member in interaction.guild.members
             if member.joined_at > datetime.now(tz=ZoneInfo("Australia/Brisbane")) - self.NEW_MEMBER_TIME
         ]
-        await interaction.response.send_message(f"There are currently {interaction.guild.member_count} members in the UQCS discord server, with {len(new_members)} joining in the last 7 days.")
+        await interaction.response.send_message(f"There are currently {interaction.guild.member_count} members in the UQ Computing Society discord, with {len(new_members)} joining in the last 7 days.")
 
     @commands.Cog.listener()
     async def on_member_join(self, _):

--- a/uqcsbot/member_counter.py
+++ b/uqcsbot/member_counter.py
@@ -53,7 +53,7 @@ class MemberCounter(commands.Cog):
             for member in interaction.guild.members
             if member.joined_at > datetime.now(tz=ZoneInfo("Australia/Brisbane")) - self.NEW_MEMBER_TIME
         ]
-        await interaction.response.send_message(f"There are currently {interaction.guild.member_count} members in the UQ Computing Society discord, with {len(new_members)} joining in the last 7 
+        await interaction.response.send_message(f"There are currently {interaction.guild.member_count} members in the UQ Computing Society discord, with {len(new_members)} joining in the last 7 days.")
         await self.attempt_update_member_count_channel_name()
 
     @commands.Cog.listener()

--- a/uqcsbot/member_counter.py
+++ b/uqcsbot/member_counter.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timedelta
 import os
 import asyncio
+from zoneinfo import ZoneInfo
 
 import discord
 from discord import app_commands
@@ -42,11 +43,12 @@ class MemberCounter(commands.Cog):
     @app_commands.command(name="membercount")
     async def member_count(self, interaction: discord.Interaction):
         """ Display the number of members """
-        new_members = filter(
-            lambda member: member.joined_at > datetime.now() - self.NEW_MEMBER_TIME,
-            interaction.guild.members
-        )
-        await interaction.response.send_message(f"There are currently {interaction.guild.member_count} members in the UQCS discord server, with {len([new_members])} joining in the last 7 days.")
+        new_members = [
+            member
+            for member in interaction.guild.members
+            if member.joined_at > datetime.now(tz=ZoneInfo("Australia/Brisbane")) - self.NEW_MEMBER_TIME
+        ]
+        await interaction.response.send_message(f"There are currently {interaction.guild.member_count} members in the UQCS discord server, with {len(new_members)} joining in the last 7 days.")
 
     @commands.Cog.listener()
     async def on_member_join(self, _):

--- a/uqcsbot/member_counter.py
+++ b/uqcsbot/member_counter.py
@@ -38,6 +38,11 @@ class MemberCounter(commands.Cog):
             self.member_count_channel = None # TODO maybe end this cog or something similar
             return
 
+        bot_member = self.bot.uqcs_server.get_member(self.bot.user.id)
+        permissions = self.member_count_channel.permissions_for(bot_member)
+        if not permissions.manage_channels:
+            logging.warning(
+                f"Bot does not have the permission to manage the #Member Count channel. The current permissions are {permissions}. The bot user is {bot_member}.")
         await self.attempt_update_member_count_channel_name()
 
     @app_commands.command(name="membercount")


### PR DESCRIPTION
`/membercount` did not work on the main server (despite working on the test server) due to permissions. Here are some error catching and logging mechanisms to allow easy checking of bot permissions and reasons for failure.