### PR TITLE
Haiku: Fixed small bugs with miscounting and allowed channels

### DIFF
--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -1,4 +1,5 @@
-from uqcsbot.haiku import _number_of_syllables_in_word, _find_haiku
+# For testing private methods, we need to tell pyright to be quiet
+from uqcsbot.haiku import _number_of_syllables_in_word, _find_haiku # pyright: ignore [reportPrivateUsage]
 
 
 def test_number_of_syllables_in_word():
@@ -303,6 +304,12 @@ def test_number_of_syllables_in_word():
         "algorithm": 4,
         "the": 1,
         "poem": 2,
+        "Chromium": 3,
+        "YT": 2,
+        "Bayes": 1,
+        "yes": 1,
+        "theorem": 2,
+        "stadium": 3,
     }
     for word, expected_syllable_count in test_cases.items():
         assert _number_of_syllables_in_word(word) == expected_syllable_count

--- a/uqcsbot/haiku.py
+++ b/uqcsbot/haiku.py
@@ -296,7 +296,7 @@ def _number_of_syllables_in_word(word: str) -> int:
     # Accounts for silent "e" at the ends of words
     if (
         word.endswith("e")
-        and not word.endswith(("ae", "ee", "ie", "oe", "ue"))
+        and not word.endswith(("ae", "ee", "ie", "oe", "ue", "ye"))
         and _number_of_vowel_groups(word.removesuffix("e")) > 0
     ):
         number_of_syllables -= 1
@@ -312,6 +312,7 @@ def _number_of_syllables_in_word(word: str) -> int:
     # Deal with exceptions from the given prefix and suffix lists
     if word.startswith(affixes["prefixes_needing_extra_syllable"]):
         number_of_syllables += 1
+    print(f"{word} {number_of_syllables}")
     if word.startswith(affixes["prefixes_needing_one_less_syllable"]):
         number_of_syllables -= 1
     if word.endswith(affixes["suffixes_needing_one_more_syllable"]):

--- a/uqcsbot/haiku.py
+++ b/uqcsbot/haiku.py
@@ -75,6 +75,8 @@ class Haiku(commands.Cog):
             raise RuntimeError(
                 f"The syllable rules (used for haiku detection) could not be found in {SYLLABLE_RULES_PATH} or did not follow the required format. Haiku detection will not work."
             )
+        # Initially set allowed_channels to be empty incase a message is recived before on_ready has completed
+        self.allowed_channels = []
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/uqcsbot/static/syllable_rules.yaml
+++ b/uqcsbot/static/syllable_rules.yaml
@@ -8,6 +8,7 @@ exceptions: {
     "bsod": 4,
     "uq": 2,
     "uqcs": 4,
+    "yt": 2,
 }
 
 # Letters to be replaced
@@ -75,7 +76,7 @@ prefixes_needing_extra_syllable: [
     "wouldnt",
     # Words ending in "e" that is considered silent, when it is not.
     "maybe", "cafe", "naive", "recipe", "abalone", "marscapone", "epitome",
-    "forte", "frappe", "eye", "acne",   
+    "forte", "frappe", "acne",   
     # Words starting with "real", "read", "reap", "rear", "reed", "reel", "reign" (see prefixes_needing_one_less_syllable) that use "re" as a prefix
     # Note that "realit" covers all words with root "reality"
     "realign", "realit", "reallocat", "readdres", "readjust", "reapp", "rearm",
@@ -163,6 +164,8 @@ suffixes_needing_one_more_syllable: [
     "ual",
     # The suffix "rior" contains two syllables in most words. For example "posterior" and "superior".
     "rior",
+    # The suffix "ium" usually contains two syllables. For example "chromium", "gymnasium" and "aquarium"
+    "ium",
     # The suffix "phe" is pronounced as a syllable, for example "apostrophe".
     "phe",
     # Words ending in "tre" have it pronounced as "ter", for example "metre" and "centre"
@@ -193,6 +196,8 @@ suffixes_needing_one_less_syllable: [
     "aisle", "isle",
     # Words containing "ue" at the end acting as a silent "e"
     "tongue", "meringue", "merengue", "vague", 
+    # Words containing "ium" at the end acting as a single syllable
+    "belgium",
 ]
 
 # REMOVED SUFFIXES


### PR DESCRIPTION
Three (and a half) small bug fixes:
 - The allowed channels list may not have loaded in time, so now a default empty list is provided.
 - Words ending in "ye" now have consistent syllable checking rules. Fixes miscounts for words like "bayes" and "yes".
 - Added an "ium" suffix to correctly count words like "gymnasium" and "chromium". Also added an exception for "belgium".
 - Added "YT" as a acronym (as it contains a vowel-like letter it wasn't detected automatically).