### PR TITLE
 Create Decorator to Prevent Use of Commands With Minuscule Argument To Bot Commands In #yelling

### DIFF
--- a/uqcsbot/cowsay.py
+++ b/uqcsbot/cowsay.py
@@ -7,6 +7,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from uqcsbot.bot import UQCSBot
+from uqcsbot.yelling import yelling_exemptor
 
 # Max length of the message to be displayed per line in the bubble.
 CowsayWrapLength = 40
@@ -49,6 +50,7 @@ class Cowsay(commands.Cog):
         tongue="Whether the cow should show its tongue (optional, default to False)",
         tux="Display the Linux Tux instead of the cow. Tux doesn't show tongue. (optional, default to False)",
     )
+    @yelling_exemptor(input_args=["message"])
     async def cowsay_command(
         self,
         interaction: discord.Interaction,
@@ -91,6 +93,7 @@ class Cowsay(commands.Cog):
         tongue="Whether the cow should show its tongue (optional, default to False)",
         tux="Display the Linux Tux instead of the cow. Tux doesn't show tongue. (optional, default to False)",
     )
+    @yelling_exemptor(input_args=["message"])
     async def cowthink_command(
         self,
         interaction: discord.Interaction,

--- a/uqcsbot/dominos_coupons.py
+++ b/uqcsbot/dominos_coupons.py
@@ -10,6 +10,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from uqcsbot.bot import UQCSBot
+from uqcsbot.yelling import yelling_exemptor
 
 
 MAX_COUPONS = 10  # Prevents abuse
@@ -36,6 +37,7 @@ class DominosCoupons(commands.Cog):
         ignore_expiry="Indicates to include coupons that have expired. Defaults to True.",
         keywords="Words to search for within the coupon. All coupons descriptions will mention at least one keyword.",
     )
+    @yelling_exemptor(input_args=["keywords"])
     async def dominoscoupons(
         self,
         interaction: discord.Interaction,

--- a/uqcsbot/gaming.py
+++ b/uqcsbot/gaming.py
@@ -11,6 +11,7 @@ from discord.ext import commands
 from requests import get
 
 from uqcsbot.bot import UQCSBot
+from uqcsbot.yelling import yelling_exemptor
 
 
 class Gaming(commands.Cog):
@@ -217,6 +218,7 @@ class Gaming(commands.Cog):
 
     @app_commands.command()
     @app_commands.describe(board_game="Board game to search for")
+    @yelling_exemptor(input_args=["board_game"])
     async def bgg(self, interaction: discord.Interaction, board_game: str):
         """
         Gets the details of the provided board game from Board Game Geek
@@ -242,6 +244,7 @@ class Gaming(commands.Cog):
 
     @app_commands.command()
     @app_commands.describe(card="Card to search for")
+    @yelling_exemptor(input_args=["card"])
     async def scry(self, interaction: discord.Interaction, card: Optional[str]):
         """
         Returns the Magic: the Gathering card that matches (partially or

--- a/uqcsbot/haiku.py
+++ b/uqcsbot/haiku.py
@@ -9,6 +9,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from uqcsbot.bot import UQCSBot
+from uqcsbot.yelling import yelling_exemptor
 
 SYLLABLE_RULES_PATH: Final[str] = "uqcsbot/static/syllable_rules.yaml"
 ALLOWED_CHANNEL_NAMES: Final[List[str]] = [
@@ -110,6 +111,7 @@ class Haiku(commands.Cog):
 
     @app_commands.command()
     @app_commands.describe(word="Word to syllable check")
+    @yelling_exemptor(input_args=["word"])
     async def syllables(self, interaction: discord.Interaction, word: str):
         """Checks the number of syllables in a given word."""
         if " " not in word:

--- a/uqcsbot/hoogle.py
+++ b/uqcsbot/hoogle.py
@@ -10,6 +10,8 @@ import html
 import re
 import urllib.parse
 
+from uqcsbot.yelling import yelling_exemptor
+
 
 class Hoogle(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -39,6 +41,7 @@ class Hoogle(commands.Cog):
 
     @app_commands.command()
     @app_commands.describe(search="Function name or type signature to search for")
+    @yelling_exemptor(input_args=["search"])
     async def hoogle(self, interaction: discord.Interaction, search: str):
         """
         Queries the Hoogle Haskell API search engine, searching Haskell libraries by either function name

--- a/uqcsbot/latex.py
+++ b/uqcsbot/latex.py
@@ -5,6 +5,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from uqcsbot.yelling import yelling_exemptor
+
 
 class Latex(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -12,6 +14,7 @@ class Latex(commands.Cog):
 
     @app_commands.command(description="Renders the given LaTeX")
     @app_commands.describe(input="LaTeX to render")
+    @yelling_exemptor(input_args=["input"])
     async def latex(self, interaction: discord.Interaction, input: str):
         # since bot prohibits empty prompts, checking len==0 seems redundant
         await interaction.response.defer(thinking=True)

--- a/uqcsbot/manage_cogs.py
+++ b/uqcsbot/manage_cogs.py
@@ -4,6 +4,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from uqcsbot.yelling import yelling_exemptor
+
 
 class ManageCogs(commands.Cog):
     """
@@ -18,6 +20,7 @@ class ManageCogs(commands.Cog):
     @app_commands.describe(
         cog='The cog (i.e. python file) to try to unload. Use python package notation, so no suffix of ".py" and "." between folders: e.g. "manage_cogs".',
     )
+    @yelling_exemptor(input_args=["cog"])
     async def manage_cogs(
         self,
         interaction: discord.Interaction,

--- a/uqcsbot/minecraft.py
+++ b/uqcsbot/minecraft.py
@@ -10,6 +10,7 @@ from discord.ext import commands
 from uqcsbot.bot import UQCSBot
 from uqcsbot.models import MCWhitelist
 from uqcsbot.utils.err_log_utils import FatalErrorWithLog
+from uqcsbot.yelling import yelling_exemptor
 
 RCON_ADDRESS = os.environ.get("MC_RCON_ADDRESS")
 RCON_PORT = os.environ.get("MC_RCON_PORT")
@@ -49,6 +50,7 @@ class Minecraft(commands.Cog):
 
     @app_commands.command()
     @app_commands.describe(username="Minecraft username to whitelist.")
+    @yelling_exemptor(input_args=["username"])
     async def mcwhitelist(self, interaction: discord.Interaction, username: str):
         """Adds a username to the whitelist for the UQCS server."""
         db_session = self.bot.create_db_session()

--- a/uqcsbot/models.py
+++ b/uqcsbot/models.py
@@ -75,5 +75,7 @@ class Starboard(Base):
 class YellingBans(Base):
     __tablename__ = "yellingbans"
 
-    user_id: Mapped[int] = mapped_column("user_id", BigInteger, primary_key=True, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        "user_id", BigInteger, primary_key=True, nullable=False
+    )
     value: Mapped[int] = mapped_column("value", BigInteger, nullable=False)

--- a/uqcsbot/models.py
+++ b/uqcsbot/models.py
@@ -70,3 +70,10 @@ class Starboard(Base):
     sent: Mapped[Optional[int]] = mapped_column(
         "sent", BigInteger, primary_key=True, nullable=True, unique=True
     )
+
+
+class YellingBans(Base):
+    __tablename__ = "yellingbans"
+
+    user_id: Mapped[int] = mapped_column("user_id", BigInteger, primary_key=True, nullable=False)
+    value: Mapped[int] = mapped_column("value", BigInteger, nullable=False)

--- a/uqcsbot/morse.py
+++ b/uqcsbot/morse.py
@@ -7,6 +7,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from uqcsbot.bot import UQCSBot
+from uqcsbot.yelling import yelling_exemptor
 
 # value of all valid ascii values in morse code
 MorseCodeDict = {
@@ -70,6 +71,7 @@ class Morse(commands.Cog):
 
     @app_commands.command(name="morse")
     @app_commands.describe(message="The message to be converted to morse code")
+    @yelling_exemptor(input_args=["message"])
     async def morse_command(
         self, interaction: discord.Interaction, message: str
     ) -> None:

--- a/uqcsbot/past_exams.py
+++ b/uqcsbot/past_exams.py
@@ -11,6 +11,7 @@ from uqcsbot.utils.uq_course_utils import (
     get_past_exams_page_url,
     HttpException,
 )
+from uqcsbot.yelling import yelling_exemptor
 
 SemesterType = Optional[Literal["Sem 1", "Sem 2", "Summer"]]
 
@@ -26,6 +27,7 @@ class PastExams(commands.Cog):
         semester="The semester to find exams for. Leave blank for all semesters.",
         random_exam="Whether to select a single random exam.",
     )
+    @yelling_exemptor(input_args=["course_code"])
     async def pastexams(
         self,
         interaction: discord.Interaction,

--- a/uqcsbot/phonetics.py
+++ b/uqcsbot/phonetics.py
@@ -2,6 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from uqcsbot.yelling import yelling_exemptor
+
 # X-SAMPA is basically a giant lookup table of symbols. It is split up into tables of
 # length 4, 3, 2, and 1 for ease of decoding. This is not the most efficient way to
 # convert X-SAMPA to Unicode, but it is definitely the simplest + easiest to understand.
@@ -169,6 +171,7 @@ class Phonetics(commands.Cog):
 
     @app_commands.command()
     @app_commands.describe(input="X-SAMPA to convert")
+    @yelling_exemptor(input_args=["input"])
     async def xsampa(self, interaction: discord.Interaction, input: str):
         """
         Converts X-SAMPA to IPA

--- a/uqcsbot/text.py
+++ b/uqcsbot/text.py
@@ -6,6 +6,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from uqcsbot.yelling import yelling_exemptor
+
 
 async def encoding_autocomplete(
     interaction: discord.Interaction, current: str
@@ -70,6 +72,7 @@ class Text(commands.Cog):
         message="Input string", encoding="Character encoding to use, defaults to UTF-8"
     )
     @app_commands.autocomplete(encoding=encoding_autocomplete)
+    @yelling_exemptor(input_args=["message"])
     async def binify(
         self,
         interaction: discord.Interaction,
@@ -112,6 +115,7 @@ class Text(commands.Cog):
     @app_commands.describe(
         message="Text to shift", distance="Distance to shift, defaults to 13"
     )
+    @yelling_exemptor(input_args=["message"])
     async def caesar(
         self,
         interaction: discord.Interaction,
@@ -140,6 +144,7 @@ class Text(commands.Cog):
         message="Input string", encoding="Character encoding to use, defaults to UTF-8"
     )
     @app_commands.autocomplete(encoding=encoding_autocomplete)
+    @yelling_exemptor(input_args=["message"])
     async def hexify(
         self,
         interaction: discord.Interaction,
@@ -213,6 +218,7 @@ class Text(commands.Cog):
 
     @app_commands.command(name="mock")
     @app_commands.describe(text="Text to mock")
+    @yelling_exemptor()
     async def mock_command(self, interaction: discord.Interaction, text: str):
         """mOckS ThE pRovIdEd teXT."""
 
@@ -231,6 +237,7 @@ class Text(commands.Cog):
 
     @app_commands.command(name="scare")
     @app_commands.describe(text='Text to "scare"')
+    @yelling_exemptor()
     async def scare_command(self, interaction: discord.Interaction, text: str):
         """
         "adds" "scary" "quotes" "around" "the" "provided" "text"
@@ -258,6 +265,7 @@ class Text(commands.Cog):
 
     @app_commands.command(name="zalgo")
     @app_commands.describe(text="Input text")
+    @yelling_exemptor()
     async def zalgo_command(self, interaction: discord.Interaction, text: str):
         """
         Ȃd͍̋͗̃d͒̈́s̒͢ ̅̂̚͏̞̩ͅZͩ̆a̦̐ͭ́l̠̫̈́̐g̡͗ͯo̝̱̽ ̮̰͊c̢̞ͬh̩ͤ̑a̡̫̟͐̽̌r̪̭͇̓a̘͕̣c͓̐́t̠̂̈̓e̳̣̣͂̉r͓͗s͉̞͝ t̙͓̊ͨoͭ ̋̽͊t̛̖̮̊͋hͤ̂͏̯̺͚e̷͖̩̙̿ ͇̩̕ğ̵̟̘̼i̢͙̜v̲ͫ͘e͐͐͆̕n͟ ̭͋͢ͅt͐͆̀e̝̱͑͛x̝̲t͇͕

--- a/uqcsbot/voteythumbs.py
+++ b/uqcsbot/voteythumbs.py
@@ -2,6 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from uqcsbot.yelling import yelling_exemptor
+
 
 class VoteyThumbs(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -37,6 +39,7 @@ class VoteyThumbs(commands.Cog):
 
     @app_commands.command(name="voteythumbs")
     @app_commands.describe(question="The question that shall be voted upon")
+    @yelling_exemptor(input_args=["question"])
     async def voteythumbs_command(
         self, interaction: discord.Interaction, question: str
     ):

--- a/uqcsbot/whatsdue.py
+++ b/uqcsbot/whatsdue.py
@@ -6,6 +6,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from uqcsbot.yelling import yelling_exemptor
+
 from uqcsbot.utils.uq_course_utils import (
     Offering,
     CourseNotFoundException,
@@ -33,6 +35,9 @@ class WhatsDue(commands.Cog):
         course4="Course code",
         course5="Course code",
         course6="Course code",
+    )
+    @yelling_exemptor(
+        input_args=["course1", "course2", "course3", "course4", "course5", "course6"]
     )
     async def whatsdue(
         self,

--- a/uqcsbot/whatweekisit.py
+++ b/uqcsbot/whatweekisit.py
@@ -9,6 +9,8 @@ from math import ceil
 from bs4 import BeautifulSoup
 from discord.ext import commands
 
+from uqcsbot.yelling import yelling_exemptor
+
 # Endpoint that contains a table of semester dates
 MARKUP_CALENDAR_URL: str = "https://systems-training.its.uq.edu.au/systems/student-systems/electronic-course-profile-system/design-or-edit-course-profile/academic-calendar-teaching-week"
 DATE_FORMAT = "%d/%m/%Y"
@@ -121,6 +123,7 @@ class WhatWeekIsIt(commands.Cog):
     @app_commands.describe(
         date="Date to lookup in the format of %d/%m/%Y (defaults to today)"
     )
+    @yelling_exemptor(input_args=["date"])
     async def whatweekisit(self, interaction: discord.Interaction, date: Optional[str]):
         """
         Sends information about which semester, week and weekday it is.

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -55,15 +55,17 @@ class Yelling(commands.Cog):
 
     async def handle_bans(self, author: discord.Member):
         db_session = self.bot.create_db_session()
-        yellingbans_query = db_session.query(YellingBans)
-        for i in yellingbans_query:
-            if i.user_id == author.id:
-                value = i.value
-                i.value += 1
-                break
-        else:
+        yellingbans_query = (
+            db_session.query(YellingBans)
+            .filter(YellingBans.user_id == author.id)
+            .one_or_none()
+        )
+        if yellingbans_query is None:
             value = 0
             db_session.add(YellingBans(user_id=author.id, value=1))
+        else:
+            value = yellingbans_query.value
+            yellingbans_query.value += 1
         db_session.commit()
         db_session.close()
 

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -33,6 +33,8 @@ class Yelling(commands.Cog):
 
         if self.contains_lowercase(text):
             await new.reply(self.generate_response(text))
+            if isinstance(msg.author, discord.Member):
+                await self.handle_bans(msg.author)
 
     @commands.Cog.listener()
     async def on_message(self, msg: discord.Message):

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -33,8 +33,8 @@ class Yelling(commands.Cog):
 
         if self.contains_lowercase(text):
             await new.reply(self.generate_response(text))
-            if isinstance(msg.author, discord.Member):
-                await self.handle_bans(msg.author)
+            if isinstance(new.author, discord.Member):
+                await self.handle_bans(new.author)
 
     @commands.Cog.listener()
     async def on_message(self, msg: discord.Message):


### PR DESCRIPTION
The decorator `@yelling_exemptor()` applied to a command will now prevent that command from being used in `#yelling`. Argument can be given to the decorator, which will apply the minuscule filter to those command arguments e.g. `input_args=["message"]` will prevent the command from being used for a command that has `message` as an argument.