### PR TITLE
fix broken yelling exemptor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,4 @@ exclude = [
     "**/utils/command_utils.py",
     "**/utils/snailrace_utils.py",
 ]
+

--- a/uqcsbot/cog.py
+++ b/uqcsbot/cog.py
@@ -1,0 +1,7 @@
+from discord.ext import commands
+
+from uqcsbot.bot import UQCSBot 
+
+class UQCSBotCog(commands.Cog):
+    def __init__(self, bot: UQCSBot):
+        self.bot = bot

--- a/uqcsbot/cog.py
+++ b/uqcsbot/cog.py
@@ -1,6 +1,7 @@
 from discord.ext import commands
 
-from uqcsbot.bot import UQCSBot 
+from uqcsbot.bot import UQCSBot
+
 
 class UQCSBotCog(commands.Cog):
     def __init__(self, bot: UQCSBot):

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -7,6 +7,7 @@ from urllib.request import urlopen
 from urllib.error import URLError
 
 from uqcsbot.bot import UQCSBot
+from uqcsbot.cog import UQCSBotCog
 from uqcsbot.models import YellingBans
 
 from datetime import timedelta
@@ -17,39 +18,39 @@ def yelling_exemptor(input_args: List[str] = ["text"]) -> Callable[..., Any]:
     def handler(func: Callable[..., Any]):
         @wraps(func)
         async def wrapper(
-            cogself: commands.Cog, *args: List[Any], **kwargs: Dict[str, Any]
+            cogself: UQCSBotCog, *args: List[Any], **kwargs: Dict[str, Any]
         ):
-            bot = cogself.bot  # type: ignore
+            bot = cogself.bot
             interaction = None
             text = "".join([str(kwargs.get(i, "") or "") for i in input_args])
             if text == "":
-                await func(bot, *args, **kwargs)
+                await func(cogself, *args, **kwargs)
                 return
             for a in args:
                 if isinstance(a, discord.interactions.Interaction):
                     interaction = a
                     break
             if interaction is None:
-                await func(bot, *args, **kwargs)
+                await func(cogself, *args, **kwargs)
                 return
             if not hasattr(interaction, "channel"):
-                await func(bot, *args, **kwargs)
+                await func(cogself, *args, **kwargs)
                 return
             if interaction.channel is None:
-                await func(bot, *args, **kwargs)
+                await func(cogself, *args, **kwargs)
                 return
             if interaction.channel.type != discord.ChannelType.text:
-                await func(bot, *args, **kwargs)
+                await func(cogself, *args, **kwargs)
                 return
             if interaction.channel.name != "yelling":
-                await func(bot, *args, **kwargs)
+                await func(cogself, *args, **kwargs)
                 return
             if not Yelling.contains_lowercase(text):
-                await func(bot, *args, **kwargs)
+                await func(cogself, *args, **kwargs)
                 return
-            await interaction.response.send_message(str(discord.utils.get(bot.emojis, name="disapproval") or ""))  # type: ignore
+            await interaction.response.send_message(str(discord.utils.get(bot.emojis, name="disapproval") or ""))
             if isinstance(interaction.user, discord.Member):
-                await Yelling.external_handle_bans(bot, interaction.user)  # type: ignore
+                await Yelling.external_handle_bans(bot, interaction.user)
 
         return wrapper
 

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -48,7 +48,9 @@ def yelling_exemptor(input_args: List[str] = ["text"]) -> Callable[..., Any]:
             if not Yelling.contains_lowercase(text):
                 await func(cogself, *args, **kwargs)
                 return
-            await interaction.response.send_message(str(discord.utils.get(bot.emojis, name="disapproval") or ""))
+            await interaction.response.send_message(
+                str(discord.utils.get(bot.emojis, name="disapproval") or "")
+            )
             if isinstance(interaction.user, discord.Member):
                 await Yelling.external_handle_bans(bot, interaction.user)
 


### PR DESCRIPTION
The yelling exemptor breaks literally any command that uses `self`. This includes `bgg`, `cowsay`, `hoogle`, `manage_cogs`, `mcwhitelist`, `voteythumbs`, and `zalgo`.

This is the sort of issue that `pyright` *should* be able to pick up (and in fact, this PR currently shouldn't pass a typecheck, because every time you apply the yelling exemptor, it unthinkingly casts `commands.Cog` down to `UQCSBotCog`). The fact that it doesn't concerns me and I may have to investigate pyright configs to work out why this is the case.