### PR TITLE
fix permission checks on starboard interactions & manage_cogs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -851,13 +851,13 @@ files = [
 
 [[package]]
 name = "pyright"
-version = "1.1.316"
+version = "1.1.334"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.316-py3-none-any.whl", hash = "sha256:7259d73287c882f933d8cd88c238ef02336e172171ae95117a963a962a1fed4a"},
-    {file = "pyright-1.1.316.tar.gz", hash = "sha256:bac1baf8567b90f2082ec95b61fc1cb50a68917119212c5608a72210870c6a9a"},
+    {file = "pyright-1.1.334-py3-none-any.whl", hash = "sha256:dcb13e8358e021189672c4d6ebcad192ab061e4c7225036973ec493183c6da68"},
+    {file = "pyright-1.1.334.tar.gz", hash = "sha256:3adaf10f1f4209575dc022f9c897f7ef024639b7ea5b3cbe49302147e6949cd4"},
 ]
 
 [package.dependencies]

--- a/uqcsbot/manage_cogs.py
+++ b/uqcsbot/manage_cogs.py
@@ -5,6 +5,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from uqcsbot.yelling import yelling_exemptor
+from uqcsbot.bot import UQCSBot
 
 
 class ManageCogs(commands.Cog):
@@ -12,11 +13,11 @@ class ManageCogs(commands.Cog):
     Note that most of these commands can make the bot load files to execute. Care should be made to ensure only entrusted users have access.
     """
 
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: UQCSBot):
         self.bot = bot
 
     @app_commands.command(name="managecogs")
-    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.checks.has_permissions(manage_guild=True)
     @app_commands.describe(
         cog='The cog (i.e. python file) to try to unload. Use python package notation, so no suffix of ".py" and "." between folders: e.g. "manage_cogs".',
     )
@@ -49,5 +50,5 @@ class ManageCogs(commands.Cog):
         await self.bot.tree.sync()
 
 
-async def setup(bot: commands.Bot):
+async def setup(bot: UQCSBot):
     await bot.add_cog(ManageCogs(bot))

--- a/uqcsbot/starboard.py
+++ b/uqcsbot/starboard.py
@@ -62,7 +62,7 @@ class Starboard(commands.Cog):
         )
 
     @app_commands.command()
-    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.checks.has_permissions(manage_guild=True)
     async def cleanup_starboard(self, interaction: discord.Interaction):
         """Cleans up the last 100 messages from the starboard.
         Removes any uqcsbot message that doesn't have a corresponding message id in the db, regardless of recv.
@@ -70,7 +70,6 @@ class Starboard(commands.Cog):
 
         manage_guild perms: for committee and infra use.
         """
-
         if interaction.channel == self.starboard_channel:
             # because if you do it from in the starboard, it deletes its own interaction response
             # and i cba making it not do that, so i'll just forbid doing it in starboard.
@@ -146,7 +145,7 @@ class Starboard(commands.Cog):
             )
         )
 
-    @app_commands.default_permissions(manage_messages=True)
+    @app_commands.checks.has_permissions(manage_messages=True)
     async def context_blacklist_sb_message(
         self, interaction: discord.Interaction, message: discord.Message
     ):
@@ -194,7 +193,7 @@ class Starboard(commands.Cog):
             f"Blacklisted message {message.id}.", ephemeral=True
         )
 
-    @app_commands.default_permissions(manage_messages=True)
+    @app_commands.checks.has_permissions(manage_messages=True)
     async def context_unblacklist_sb_message(
         self, interaction: discord.Interaction, message: discord.Message
     ):


### PR DESCRIPTION
The default_permissions() decorator lets DMs through. This is cringe - we want to use default_permissions so that the server's role & moderation processes are abstracted out of the bot's code, and future committees can just fiddle with discord settings.

A more long-term solution is to have a decorator, `@requires_server` or the like, so we can continue to use default_permissions and just require that some commands must be used in the server. (This also would fix several other DM-based errors this PR identifies.) However, for now, let's just switch them all to `checks.has_permissions()` instead.

`grep -r permission` shows the following cogs use permissions:
- member_count: errors out on DMs anyway (should be fixed but who cares)
- minecraft: uses has_permissions() and Member-type-checks anyway
- remindme: has manual permission checks, these will throw `AttributeError` in DMs (should be fixed but who cares)
- starboard: fixed
- manage_cogs: fixed