### PR TITLE
SECaT slash command and course statistics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ humanize = "^4.3"
 aiohttp = "^3.8"
 aio-mc-rcon = "^3.2.0"
 PyYAML = "^6.0"
+pandas = "^2.1.3"
+matplotlib = "^3.8.1"
 
 [tool.poetry.scripts]
 botdev = "dev.cli:main"

--- a/uqcsbot/secats.py
+++ b/uqcsbot/secats.py
@@ -4,13 +4,28 @@ from bisect import bisect_left
 import requests
 import pandas as pd
 from bs4 import BeautifulSoup
+import functools
+from typing import Optional
+import logging
+
+
+def binsearch(a, x, key=None):
+    """Binary search using bisect_left."""
+    pos = bisect_left(a, x, key=key)
+    if pos != len(a) and a[pos] == x:
+        return pos
+    else:
+        raise ValueError(f"`{x}` is not present within `a`")
 
 
 class SECaTs:
-    url = "https://www.pbi.uq.edu.au/clientservices/SECaT/embedChart.aspx"
+    """Small scrapper class for SECaTs."""
+
+    URL = "https://www.pbi.uq.edu.au/clientservices/SECaT/embedChart.aspx"
 
     def __init__(self):
-        firstPage = requests.post(self.url).content
+        self.session = requests.Session()
+        firstPage = self.session.post(self.URL).content
         self.soup = BeautifulSoup(firstPage, "html.parser")
 
         self.viewstategenerator = self.soup.find(
@@ -22,29 +37,7 @@ class SECaTs:
 
         # Caches
         self.viewstates = {"": self.viewstate}
-        self.lvl2_eventargs = {}
-        self.lvl3_eventargs = {}
-
-    def get(self, index: list[str]) -> pd.DataFrame:
-        assert 0 < len(index) <= 4
-
-        vs = self.viewstate
-        for i in range(1, len(index) + 1):
-            eventarg = ":".join(index[:i])
-            data = {
-                "__EVENTTARGET": "RadTabStrip1",
-                "__EVENTARGUMENT": f"""{{"type":0,"index":"{eventarg}"}}""",
-                "__VIEWSTATE": vs,
-                "__VIEWSTATEGENERATOR": self.viewstategenerator,
-            }
-            res = requests.post(self.url, data=data).content.decode("utf8")
-
-            soup = BeautifulSoup(res, "html.parser")
-            vs = soup.find("input", {"id": "__VIEWSTATE"}).get("value")
-
-        for script in soup.find_all("script"):
-            if script.string and (match := self.pattern.match(script.string)):
-                return pd.DataFrame(json.loads(match.group(1)))
+        self.secats = {}
 
     def __get_vs(self, eventarg: str) -> str:
         """
@@ -54,7 +47,8 @@ class SECaTs:
         """
         print("Getting vs for:", eventarg)
         # Find the previous state
-        prev_eventarg = eventarg[:eventarg.rfind(":")]
+        idx = eventarg.rfind(":")
+        prev_eventarg = eventarg[:idx] if idx != -1 else ""
         vs = self.viewstates.get(prev_eventarg, None)
         if vs is None:
             print("Didn't find", prev_eventarg, "in cache")
@@ -68,7 +62,7 @@ class SECaTs:
             "__VIEWSTATEGENERATOR": self.viewstategenerator,
         }
         print("Requesting:", eventarg)
-        res = requests.post(self.url, data=data).content.decode("utf8")
+        res = self.session.post(self.URL, data=data).content.decode("utf8")
 
         soup = BeautifulSoup(res, "html.parser")
         vs = soup.find("input", {"id": "__VIEWSTATE"}).get("value")
@@ -77,7 +71,7 @@ class SECaTs:
 
     def __get_lvl1_ea(self, letter: str) -> str:
         """
-        Get the eventarg for the level 1 menu.
+        Get the eventarg for the level 1 menu for `letter`.
 
         This corropsonds the the first letter of the course code.
 
@@ -88,68 +82,117 @@ class SECaTs:
         Returns the parsed page and viewstate directly from `__get_vs` and the
         eventarg used.
         """
-        print("Getting lvl1 vs for:", letter)
+        # print("Getting lvl1 vs for:", letter)
         assert len(letter) == 1 and "A" <= letter <= "W"
 
         eventarg = str(ord(letter) - ord("A"))
         return eventarg
 
+    @functools.cache
     def __get_lvl2_ea(self, letters: str) -> str:
         """
-        Get the eventarg for the level 2 menu.
+        Get the eventarg for the level 2 menu for `letters`.
 
         This corropsonds the first 4 letters of the course code.
         """
         print("Getting lvl2 vs for:", letters)
         assert len(letters) == 4
 
-        eventarg = self.lvl2_eventargs.get(letters, None)
-        if eventarg is None:
-            print("Didn't find", letters, "in lvl2 cache")
-            soup, vs, eventarg = self.__get_lvl1_vs(letters[0])
+        eventarg = self.__get_lvl1_ea(letters[0])
+        soup, vs = self.__get_vs(eventarg)
 
-            codes = [
-                x.text
-                for x in soup.find("div", "rtsLevel rtsLevel2").find_all("span", "rtsTxt")
-            ]
-            eventarg = eventarg + ":" + str(bisect_left(codes, letters))
-            self.lvl2_eventargs[letters] = eventarg
+        codes = [
+            x.text
+            for x in soup.find("div", "rtsLevel rtsLevel2").find_all("span", "rtsTxt")
+        ]
+        return eventarg + ":" + str(binsearch(codes, letters))
 
-        return *self.__get_vs(eventarg), eventarg
-
-    def __get_lvl3_vs(self, code: str) -> str:
+    @functools.cache
+    def __get_lvl3_ea(self, code: str) -> str:
         """
-        Get the viewstate for the level 3 menu.
+        Get the eventarg for the level 3 menu for `code`.
 
         This corropsonds the full course code.
         """
         print("Getting lvl3 vs for:", code)
         assert len(code) == 8
 
-        eventarg = self.lvl3_eventargs.get(code, None)
-        if eventarg is None:
-            print("Didn't find", code, "in lvl3 cache")
-            soup, vs, eventarg = self.__get_lvl2_vs(code[:4])
+        eventarg = self.__get_lvl2_ea(code[:4])
+        soup, vs = self.__get_vs(eventarg)
 
-            # We specifically want the *unstyled* elements, otherwise we'll get all
-            # the courses under code[:4]
-            courses = [
-                x.text
-                for x in soup.find("div", "rtsLevel rtsLevel3")
-                .find("ul", style=False)
-                .find_all("span", "rtsTxt")
-            ]
-            eventarg = eventarg + ":" + str(bisect_left(courses, code))
-            self.lvl3_eventargs[code] = eventarg
+        # We specifically want the *unstyled* elements, otherwise we'll get all
+        # the courses under code[:4]
+        courses = [
+            x.text
+            for x in soup.find("div", "rtsLevel rtsLevel3")
+            .find("ul", style=False)
+            .find_all("span", "rtsTxt")
+        ]
+        return eventarg + ":" + str(binsearch(courses, code))
 
-        return *self.__get_vs(eventarg), eventarg
+    @functools.cache
+    def __get_lvl4_ea(self, code: str, semester: str) -> str:
+        r"""
+        Get the eventarg for the level 4 menu for `code` and `semester`.
 
-    def get_latest(self, code: str) -> pd.DataFrame:
-        """Get the latest SECaT corrosponding to the course code."""
-        print("Getting latest for:", code)
+        `semester` must be of the form "^Semester [12], 20\d{2}$".
 
-        soup, _, _ = self.__get_lvl3_vs(code)
+        This corropsonds the full course code and semester pair.
+        """
+        print("Getting lvl4 vs for:", code, semester)
+        assert len(code) == 8 and re.match(r"^Semester [12], 20\d{2}$", semester)
 
+        eventarg = self.__get_lvl3_ea(code)
+        soup, vs = self.__get_vs(eventarg)
+
+        # We specifically want the *unstyled* elements, otherwise we'll get all
+        # the semesters under code[:4]. Actually I'm not sure what we'll get
+        # but we don't want the styled ones anyway (they are "display:none;")
+        semesters = [
+            x.text
+            for x in soup.find("div", "rtsLevel rtsLevel4")
+            .find("ul", style=False)
+            .find_all("span", "rtsTxt")
+        ]
+        # Semesters are sorted in most recent to oldest, unfortunately thats
+        # the same as decending colexicographic ordering, so we'll just use
+        # .index()
+        return eventarg + ":" + str(semesters.index(code + ": " + semester))
+
+    def __extract(self, soup: BeautifulSoup) -> pd.DataFrame:
         for script in soup.find_all("script"):
             if script.string and (match := self.pattern.match(script.string)):
                 return pd.DataFrame(json.loads(match.group(1)))
+
+    def get(self, code: str, semester: Optional[str] = None) -> pd.DataFrame:
+        r"""
+        Get the latest SECaT or the semester corrosponding to the course code.
+
+        `len(code)` must be 8.
+
+        `semester` must be of the form "^Semester [12], 20\d{2}$".
+        """
+        assert len(code) == 8
+        code = code.upper()
+
+        try:
+            if semester is None:
+                soup, _ = self.__get_vs(self.__get_lvl3_ea(code))
+            else:
+                assert re.match(r"^Semester [12], 20\d{2}$", semester)
+                soup, _ = self.__get_vs(self.__get_lvl4_ea(code, semester))
+        except requests.RequestException as exception:
+            logging.error(exception.response.content)
+
+        return self.__extract(soup)
+
+
+
+import asyncio
+
+async def main():
+    print('Hello ...')
+    await asyncio.sleep(1)
+    print('... World!')
+
+asyncio.run(main())

--- a/uqcsbot/secats.py
+++ b/uqcsbot/secats.py
@@ -1,0 +1,155 @@
+import re
+import json
+from bisect import bisect_left
+import requests
+import pandas as pd
+from bs4 import BeautifulSoup
+
+
+class SECaTs:
+    url = "https://www.pbi.uq.edu.au/clientservices/SECaT/embedChart.aspx"
+
+    def __init__(self):
+        firstPage = requests.post(self.url).content
+        self.soup = BeautifulSoup(firstPage, "html.parser")
+
+        self.viewstategenerator = self.soup.find(
+            "input", {"id": "__VIEWSTATEGENERATOR"}
+        ).get("value")
+        self.viewstate = self.soup.find("input", {"id": "__VIEWSTATE"}).get("value")
+
+        self.pattern = re.compile(r"\s*var courseSECATData = (.*?);", re.S)
+
+        # Caches
+        self.viewstates = {"": self.viewstate}
+        self.lvl2_eventargs = {}
+        self.lvl3_eventargs = {}
+
+    def get(self, index: list[str]) -> pd.DataFrame:
+        assert 0 < len(index) <= 4
+
+        vs = self.viewstate
+        for i in range(1, len(index) + 1):
+            eventarg = ":".join(index[:i])
+            data = {
+                "__EVENTTARGET": "RadTabStrip1",
+                "__EVENTARGUMENT": f"""{{"type":0,"index":"{eventarg}"}}""",
+                "__VIEWSTATE": vs,
+                "__VIEWSTATEGENERATOR": self.viewstategenerator,
+            }
+            res = requests.post(self.url, data=data).content.decode("utf8")
+
+            soup = BeautifulSoup(res, "html.parser")
+            vs = soup.find("input", {"id": "__VIEWSTATE"}).get("value")
+
+        for script in soup.find_all("script"):
+            if script.string and (match := self.pattern.match(script.string)):
+                return pd.DataFrame(json.loads(match.group(1)))
+
+    def __get_vs(self, eventarg: str) -> str:
+        """
+        Get the viewstate for `index` recursively, adding new states to the cache.
+
+        Returns the parsed page and viewstate.
+        """
+        print("Getting vs for:", eventarg)
+        # Find the previous state
+        prev_eventarg = eventarg[:eventarg.rfind(":")]
+        vs = self.viewstates.get(prev_eventarg, None)
+        if vs is None:
+            print("Didn't find", prev_eventarg, "in cache")
+            _, vs = self.__get_vs(prev_eventarg)
+
+        # Make our new request
+        data = {
+            "__EVENTTARGET": "RadTabStrip1",
+            "__EVENTARGUMENT": f"""{{"type":0,"index":"{eventarg}"}}""",
+            "__VIEWSTATE": vs,
+            "__VIEWSTATEGENERATOR": self.viewstategenerator,
+        }
+        print("Requesting:", eventarg)
+        res = requests.post(self.url, data=data).content.decode("utf8")
+
+        soup = BeautifulSoup(res, "html.parser")
+        vs = soup.find("input", {"id": "__VIEWSTATE"}).get("value")
+        self.viewstates[eventarg] = vs
+        return soup, vs
+
+    def __get_lvl1_ea(self, letter: str) -> str:
+        """
+        Get the eventarg for the level 1 menu.
+
+        This corropsonds the the first letter of the course code.
+
+        Parsing the letters from the page isn't required since A-W exist
+        already but can be done:
+        [x.text for x in soup.find("div", "rtsLevel rtsLevel1").find_all("span", "rtsTxt")]
+
+        Returns the parsed page and viewstate directly from `__get_vs` and the
+        eventarg used.
+        """
+        print("Getting lvl1 vs for:", letter)
+        assert len(letter) == 1 and "A" <= letter <= "W"
+
+        eventarg = str(ord(letter) - ord("A"))
+        return eventarg
+
+    def __get_lvl2_ea(self, letters: str) -> str:
+        """
+        Get the eventarg for the level 2 menu.
+
+        This corropsonds the first 4 letters of the course code.
+        """
+        print("Getting lvl2 vs for:", letters)
+        assert len(letters) == 4
+
+        eventarg = self.lvl2_eventargs.get(letters, None)
+        if eventarg is None:
+            print("Didn't find", letters, "in lvl2 cache")
+            soup, vs, eventarg = self.__get_lvl1_vs(letters[0])
+
+            codes = [
+                x.text
+                for x in soup.find("div", "rtsLevel rtsLevel2").find_all("span", "rtsTxt")
+            ]
+            eventarg = eventarg + ":" + str(bisect_left(codes, letters))
+            self.lvl2_eventargs[letters] = eventarg
+
+        return *self.__get_vs(eventarg), eventarg
+
+    def __get_lvl3_vs(self, code: str) -> str:
+        """
+        Get the viewstate for the level 3 menu.
+
+        This corropsonds the full course code.
+        """
+        print("Getting lvl3 vs for:", code)
+        assert len(code) == 8
+
+        eventarg = self.lvl3_eventargs.get(code, None)
+        if eventarg is None:
+            print("Didn't find", code, "in lvl3 cache")
+            soup, vs, eventarg = self.__get_lvl2_vs(code[:4])
+
+            # We specifically want the *unstyled* elements, otherwise we'll get all
+            # the courses under code[:4]
+            courses = [
+                x.text
+                for x in soup.find("div", "rtsLevel rtsLevel3")
+                .find("ul", style=False)
+                .find_all("span", "rtsTxt")
+            ]
+            eventarg = eventarg + ":" + str(bisect_left(courses, code))
+            self.lvl3_eventargs[code] = eventarg
+
+        return *self.__get_vs(eventarg), eventarg
+
+    def get_latest(self, code: str) -> pd.DataFrame:
+        """Get the latest SECaT corrosponding to the course code."""
+        print("Getting latest for:", code)
+
+        soup, _, _ = self.__get_lvl3_vs(code)
+
+        for script in soup.find_all("script"):
+            if script.string and (match := self.pattern.match(script.string)):
+                return pd.DataFrame(json.loads(match.group(1)))


### PR DESCRIPTION
This is the accompanying PR to #180. I've just finished my exams and thought I'd follow up on the scrapper and get it into a working and shareable shape.

Current state:
- [X] Basic functionality (return responses)
![image](https://github.com/UQComputingSociety/uqcsbot-discord/assets/49361082/b412740a-ce34-4d96-961a-9eb664238550)
- [X] Cache various `viewstates` and `eventargs`
- [X] Cache SECaT responses
- [X] Basic result display
![image](https://github.com/UQComputingSociety/uqcsbot-discord/assets/49361082/d6b2eccc-f650-4919-bd05-69efc4c8c5d9)
- [ ] Basic Discord integration
- [ ] Embeds and interactive buttons
- [ ] Autocomplete
- [ ] Database storage? Everything is currently in memory only
- [ ] Tests