### PR TITLE
Fixed the bug crashing leaderboards from anonymous users

### DIFF
--- a/uqcsbot/utils/advent_utils.py
+++ b/uqcsbot/utils/advent_utils.py
@@ -34,7 +34,7 @@ class Member:
         # The advent of code id
         self.id = id
         # The advent of code name
-        self.name = name
+        self.name = name if name else "Anon"
         # The score of the user on the local leaderboard
         self.local = local
         # The total number of stars the user has collected


### PR DESCRIPTION
The name provided by the AOC JSON is null if the user is anonymous. This is not corrected (and pyright doesn't pick up this error, as JSON is typed as `Dict[str, Any]`), so causes an error when displaying leaderboards of an anonymous user. this just make people have the name "Anon" if they don't have an AOC name.