### PR TITLE
remove yelling exemptor from mcwhitelist

### DIFF
--- a/uqcsbot/minecraft.py
+++ b/uqcsbot/minecraft.py
@@ -11,7 +11,6 @@ from discord.ext import commands
 from uqcsbot.bot import UQCSBot
 from uqcsbot.models import MCWhitelist
 from uqcsbot.utils.err_log_utils import FatalErrorWithLog
-from uqcsbot.yelling import yelling_exemptor
 
 RCON_ADDRESS = os.environ.get("MC_RCON_ADDRESS")
 RCON_PORT = os.environ.get("MC_RCON_PORT")
@@ -75,7 +74,6 @@ class Minecraft(commands.Cog):
 
     @app_commands.command()
     @app_commands.describe(username="Minecraft username to whitelist.")
-    @yelling_exemptor(input_args=["username"])
     async def mcwhitelist(self, interaction: discord.Interaction, username: str):
         """Adds a username to the whitelist for the UQCS server."""
         db_session = self.bot.create_db_session()


### PR DESCRIPTION
this causes a timeout (?) when whitelisting, sometimes. idk why.

It's pointless to have the exemptor on this command anyway, because capitalising a minecraft username will probably cause it to stop working.