### PR TITLE
Removed potentially inappropriate #yelling response

### DIFF
--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -189,7 +189,6 @@ class Yelling(commands.Cog):
                 "I CAN’T UNDERSTAND YOU WHEN YOU MUMBLE!",
                 "YOU’RE GONNA NEED TO BE LOUDER!",
                 "WHY ARE YOU SO QUIET‽",
-                "QUIET PEOPLE SHOULD BE DRAGGED OUT INTO THE STREET AND SHOT!",
                 "PLEASE USE YOUR OUTSIDE VOICE!",
                 "IT’S ON THE LEFT OF THE “A” KEY!",
                 "FORMER PRESIDENT THEODORE ROOSEVELT’S FOREIGN POLICY IS A SHAM!",


### PR DESCRIPTION
As I mentioned in https://github.com/UQComputingSociety/uqcsbot-discord/issues/198, one of the messages in the #yelling responses includes an (ironic) call for violence which may make some members uncomfortable and seems inappropriate for a club-sanctioned bot to be saying.

This pull request removes that message.