### PR TITLE
Whatsdue: fixed to work with the new JAC system

### DIFF
--- a/uqcsbot/utils/uq_course_utils.py
+++ b/uqcsbot/utils/uq_course_utils.py
@@ -68,20 +68,20 @@ class Offering:
 
     def get_semester_code(self) -> int:
         """
-        Returns the code used interally within UQ for the semester of the offering.
+        Returns the code used internally within UQ for the semester of the offering.
         """
         return self.semester_codes[self.semester]
 
     def get_campus_code(self) -> str:
         """
-        Returns the code used interally within UQ for the campus of the offering.
+        Returns the code used internally within UQ for the campus of the offering.
         """
         self.campus
         return self.campus_codes[self.campus]
 
     def get_mode_code(self) -> str:
         """
-        Returns the code used interally within UQ for the mode of the offering.
+        Returns the code used internally within UQ for the mode of the offering.
         """
         return self.mode_codes[self.mode]
 
@@ -119,8 +119,7 @@ class AssessmentItem:
 
     def get_parsed_due_date(self) -> Optional[tuple[datetime, datetime]]:
         """
-        Returns the parsed due date for the given assessment item as a datetime
-        object. If the date cannot be parsed, a DateSyntaxException is raised.
+        Returns the minimum and maximum date for a particular assessment item, or None if no dates can be parsed. These will be the same if only a single date can be parsed, or will be the earliest and latest dates if multiple dates can be parsed (e.g. assignment series, or when blocks of dates are scheduled as the due dates for talks).
         """
         if self.due_date.startswith("End of Semester Exam Period"):
             return get_current_exam_period()
@@ -142,9 +141,9 @@ class AssessmentItem:
             return min(dates), max(dates)
         return None
 
-    def is_after(self, cutoff: datetime):
+    def is_after(self, cutoff: datetime) -> bool:
         """
-        Returns whether the assessment occurs after the given cutoff.
+        Returns whether the assessment ends after the given cutoff.
         """
         date_range = self.get_parsed_due_date()
         if date_range is None:
@@ -154,9 +153,9 @@ class AssessmentItem:
         _, end_datetime = date_range
         return end_datetime >= cutoff
 
-    def is_before(self, cutoff: datetime):
+    def is_before(self, cutoff: datetime) -> bool:
         """
-        Returns whether the assessment occurs before the given cutoff.
+        Returns whether the assessment starts before the given cutoff.
         """
         date_range = self.get_parsed_due_date()
         if date_range is None:
@@ -247,7 +246,7 @@ def get_uq_request(
     url: str, params: Optional[dict[str, str]] = None
 ) -> requests.Response:
     """
-    Handles specific error handelling and header provision for requests.get to
+    Handles specific error handeling and header provision for requests.get to
     uq course urls
     """
     headers = {"User-Agent": "UQCS"}
@@ -301,7 +300,7 @@ def get_course_profile_url(
     return url
 
 
-def get_current_exam_period():
+def get_current_exam_period() -> tuple[datetime, datetime]:
     """
     Returns the start and end datetimes for the current semester's exam period.
 
@@ -327,13 +326,12 @@ def get_current_exam_period():
     return start_datetime, end_datetime
 
 
-def get_course_assessment(
+def get_course_assessment_items(
     course_name: str,
     offering: Offering,
 ) -> list[AssessmentItem]:
     """
-    Returns all the assessment for the given
-    course that occur after the given cutoff.
+    Returns all the assessment for the given course.
     """
     course_profile_url = get_course_profile_url(course_name, offering=offering)
     course_assessment_url = course_profile_url + "#assessment"

--- a/uqcsbot/whatsdue.py
+++ b/uqcsbot/whatsdue.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 import logging
-from typing import Optional, Callable, Literal, Dict
+from typing import Optional, Callable, Literal
 
 import discord
 from discord import app_commands
@@ -9,15 +9,14 @@ from discord.ext import commands
 from uqcsbot.yelling import yelling_exemptor
 
 from uqcsbot.utils.uq_course_utils import (
-    DateSyntaxException,
+    AssessmentNotFoundException,
     Offering,
     CourseNotFoundException,
     HttpException,
     ProfileNotFoundException,
     AssessmentItem,
     get_course_assessment,
-    get_course_assessment_page,
-    get_course_profile_id,
+    get_course_profile_url,
 )
 
 AssessmentSortType = Literal["Date", "Course Name", "Weight"]
@@ -28,13 +27,13 @@ ECP_ASSESSMENT_URL = (
 
 def sort_by_date(item: AssessmentItem):
     """Provides a key to sort assessment dates by. If the date cannot be parsed, will put it with items occuring during exam block."""
-    try:
-        return item.get_parsed_due_date()[0]
-    except DateSyntaxException:
-        return datetime.max
+    due_date = item.get_parsed_due_date()
+    if due_date:
+        return due_date[0]
+    return datetime.max
 
 
-SORT_METHODS: Dict[
+SORT_METHODS: dict[
     AssessmentSortType, Callable[[AssessmentItem], int | str | datetime]
 ] = {
     "Date": sort_by_date,
@@ -88,27 +87,39 @@ class WhatsDue(commands.Cog):
 
         # If full output is not specified, set the cutoff to today's date.
         cutoff = (
-            None if fulloutput else datetime.today(),
+            datetime.min if fulloutput else datetime.today(),
             datetime.today() + timedelta(weeks=weeks_to_show)
             if weeks_to_show > 0
-            else None,
+            else datetime.max,
         )
+
         try:
-            assessment_page = get_course_assessment_page(course_names, offering)
-            assessment = get_course_assessment(course_names, cutoff, assessment_page)
+            assessment = [
+                get_course_assessment(course_name, offering)
+                for course_name in course_names
+            ]
+            assessment = [
+                item
+                for course in assessment
+                for item in course
+                if item.is_after(cutoff[0]) and item.is_before(cutoff[1])
+            ]
         except HttpException as e:
             logging.error(e.message)
             await interaction.edit_original_response(
                 content=f"An error occurred, please try again."
             )
             return
-        except (CourseNotFoundException, ProfileNotFoundException) as e:
+        except (
+            CourseNotFoundException,
+            ProfileNotFoundException,
+            AssessmentNotFoundException,
+        ) as e:
             await interaction.edit_original_response(content=e.message)
             return
 
         embed = discord.Embed(
             title=f"What's Due: {', '.join(course_names)}",
-            url=assessment_page,
             description="*WARNING: Assessment information may vary/change/be entirely different! Use at your own discretion. Check your ECP for a true list of assessment.*",
         )
         if assessment:
@@ -116,7 +127,7 @@ class WhatsDue(commands.Cog):
             for assessment_item in assessment:
                 embed.add_field(
                     name=assessment_item.course_name,
-                    value=f"`{assessment_item.weight}` {assessment_item.task} **({assessment_item.due_date})**",
+                    value=f"`{assessment_item.weight}` [{assessment_item.task}]({assessment_item.task_details_url}) ({assessment_item.category})\n{assessment_item.due_date}",
                     inline=False,
                 )
         elif fulloutput:
@@ -132,7 +143,7 @@ class WhatsDue(commands.Cog):
 
         if show_ecp_links:
             ecp_links = [
-                f"[{course_name}]({ECP_ASSESSMENT_URL + str(get_course_profile_id(course_name))})"
+                f"[{course_name}]({get_course_profile_url(course_name) + '#assessment'})"
                 for course_name in course_names
             ]
             embed.add_field(

--- a/uqcsbot/whatsdue.py
+++ b/uqcsbot/whatsdue.py
@@ -15,7 +15,7 @@ from uqcsbot.utils.uq_course_utils import (
     HttpException,
     ProfileNotFoundException,
     AssessmentItem,
-    get_course_assessment,
+    get_course_assessment_items,
     get_course_profile_url,
 )
 
@@ -26,7 +26,7 @@ ECP_ASSESSMENT_URL = (
 
 
 def sort_by_date(item: AssessmentItem):
-    """Provides a key to sort assessment dates by. If the date cannot be parsed, will put it with items occuring during exam block."""
+    """Provides a key to sort assessment dates by. If the date cannot be parsed, will put it with items occurring during exam block."""
     due_date = item.get_parsed_due_date()
     if due_date:
         return due_date[0]
@@ -54,8 +54,8 @@ class WhatsDue(commands.Cog):
         semester="The semester to get assessment for. Defaults to what UQCSbot believes is the current semester.",
         campus="The campus the course is held at. Defaults to St Lucia. Note that many external courses are 'hosted' at St Lucia.",
         mode="The mode of the course. Defaults to Internal.",
-        courses="Course codes seperated by spaces",
-        sort_order="The order to sort courses by. Defualts to Date.",
+        courses="Course codes separated by spaces",
+        sort_order="The order to sort courses by. Defaults to Date.",
         reverse_sort="Whether to reverse the sort order. Defaults to false.",
         show_ecp_links="Show the first ECP link for each course page. Defaults to false.",
     )
@@ -95,7 +95,7 @@ class WhatsDue(commands.Cog):
 
         try:
             assessment = [
-                get_course_assessment(course_name, offering)
+                get_course_assessment_items(course_name, offering)
                 for course_name in course_names
             ]
             assessment = [


### PR DESCRIPTION
Recently (semester 2 2024) UQ has changed their ECP management from [ECPS](https://systems-training.its.uq.edu.au/ecps) to [JAC](https://systems-training.its.uq.edu.au/jac). This means that many of the ECP related functions stopped working (as they were based off [a old service started in 2006](https://www.courses.uq.edu.au/student_section_report.php?report=assessment&profileIds=133473)).

This PR rewrites most of these to work with the new system, letting `whatsdue` work again. There are some slight stylistic changes made to the output, due to certain links no longer being available, and the due dates for many courses actually being descriptions. ECPs from before sem 2 2024 will no longer be able to be processed, as these should no longer be needed.

There might also be some future potential to include hurdle warnings in `whatsdue`, as these are in the current ECP assessment tables, but are ignored in this PR.

Please  review harshly, as I have done a somewhat quick job at this.