### PR TITLE
Adjustments to Advent of Code

### DIFF
--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -229,6 +229,7 @@ class Advent(commands.Cog):
             response = requests.get(
                 LEADERBOARD_URL.format(year=year, code=code),
                 cookies={"session": self.session_id},
+                allow_redirects=False, # Will redirct to home page if session token is out of date
             )
         except RequestException as exception:
             raise FatalErrorWithLog(
@@ -495,7 +496,7 @@ The arguments for the command have a bit of nuance. They are as follow:
             members = self._get_members(year, code)
         except InvalidHTTPSCode:
             await interaction.edit_original_response(
-                content="Error fetching leaderboard data. Check the leaderboard code and year."
+                content="Error fetching leaderboard data. Check the leaderboard code and year. If this keeps occurring, reach out to committee, as this may be due to an invalid session token."
             )
             return
         except AssertionError:

--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -603,7 +603,7 @@ The arguments for the command have a bit of nuance. They are as follow:
             )
             return
 
-        db_session.add(AOCRegistrations(aoc_userid=AOC_id, discord_userid=discord_id))
+        db_session.add(AOCRegistrations(aoc_userid=AOC_id, discord_userid=discord_id, year=2024)) # this is a quick fix unitl we drop the column in the database
         db_session.commit()
         db_session.close()
 
@@ -674,7 +674,7 @@ The arguments for the command have a bit of nuance. They are as follow:
             )
             return
 
-        db_session.add(AOCRegistrations(aoc_userid=aoc_id, discord_userid=discord_id))
+        db_session.add(AOCRegistrations(aoc_userid=aoc_id, discord_userid=discord_id, year=2024)) # this is a quick fix unitl we drop the column in the database
         db_session.commit()
         db_session.close()
 

--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -603,7 +603,9 @@ The arguments for the command have a bit of nuance. They are as follow:
             )
             return
 
-        db_session.add(AOCRegistrations(aoc_userid=AOC_id, discord_userid=discord_id, year=2024)) # this is a quick fix unitl we drop the column in the database
+        db_session.add(
+            AOCRegistrations(aoc_userid=AOC_id, discord_userid=discord_id, year=2024)
+        )  # this is a quick fix unitl we drop the column in the database
         db_session.commit()
         db_session.close()
 
@@ -674,7 +676,9 @@ The arguments for the command have a bit of nuance. They are as follow:
             )
             return
 
-        db_session.add(AOCRegistrations(aoc_userid=aoc_id, discord_userid=discord_id, year=2024)) # this is a quick fix unitl we drop the column in the database
+        db_session.add(
+            AOCRegistrations(aoc_userid=aoc_id, discord_userid=discord_id, year=2024)
+        )  # this is a quick fix unitl we drop the column in the database
         db_session.commit()
         db_session.close()
 

--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -229,7 +229,7 @@ class Advent(commands.Cog):
             response = requests.get(
                 LEADERBOARD_URL.format(year=year, code=code),
                 cookies={"session": self.session_id},
-                allow_redirects=False, # Will redirct to home page if session token is out of date
+                allow_redirects=False,  # Will redirct to home page if session token is out of date
             )
         except RequestException as exception:
             raise FatalErrorWithLog(

--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -575,9 +575,7 @@ The arguments for the command have a bit of nuance. They are as follow:
 
         query = (
             db_session.query(AOCRegistrations)
-            .filter(
-                AOCRegistrations.aoc_userid == AOC_id
-            )
+            .filter(AOCRegistrations.aoc_userid == AOC_id)
             .one_or_none()
         )
         if query is not None:
@@ -595,7 +593,7 @@ The arguments for the command have a bit of nuance. They are as follow:
         query = (
             db_session.query(AOCRegistrations)
             .filter(
-                    AOCRegistrations.discord_userid == discord_id,
+                AOCRegistrations.discord_userid == discord_id,
             )
             .one_or_none()
         )
@@ -605,9 +603,7 @@ The arguments for the command have a bit of nuance. They are as follow:
             )
             return
 
-        db_session.add(
-            AOCRegistrations(aoc_userid=AOC_id, discord_userid=discord_id)
-        )
+        db_session.add(AOCRegistrations(aoc_userid=AOC_id, discord_userid=discord_id))
         db_session.commit()
         db_session.close()
 
@@ -664,9 +660,7 @@ The arguments for the command have a bit of nuance. They are as follow:
 
         query = (
             db_session.query(AOCRegistrations)
-            .filter(
-                 AOCRegistrations.aoc_userid == aoc_id
-            )
+            .filter(AOCRegistrations.aoc_userid == aoc_id)
             .one_or_none()
         )
         if query is not None:
@@ -680,9 +674,7 @@ The arguments for the command have a bit of nuance. They are as follow:
             )
             return
 
-        db_session.add(
-            AOCRegistrations(aoc_userid=aoc_id, discord_userid=discord_id)
-        )
+        db_session.add(AOCRegistrations(aoc_userid=aoc_id, discord_userid=discord_id))
         db_session.commit()
         db_session.close()
 

--- a/uqcsbot/models.py
+++ b/uqcsbot/models.py
@@ -34,7 +34,10 @@ class AOCRegistrations(Base):
         "discord_userid", BigInteger, primary_key=True, nullable=False
     )
     aoc_userid: Mapped[int] = mapped_column("aoc_userid", Integer, nullable=False)
-    year: Mapped[int] = mapped_column("year", Integer, nullable=False) # Try to remove this column from the database at some point
+    year: Mapped[int] = mapped_column(
+        "year", Integer, nullable=False
+    )  # Try to remove this column from the database at some point
+
 
 class MCWhitelist(Base):
     __tablename__ = "mc_whitelisted"

--- a/uqcsbot/models.py
+++ b/uqcsbot/models.py
@@ -34,7 +34,6 @@ class AOCRegistrations(Base):
         "discord_userid", BigInteger, primary_key=True, nullable=False
     )
     aoc_userid: Mapped[int] = mapped_column("aoc_userid", Integer, nullable=False)
-    year: Mapped[int] = mapped_column("year", Integer, nullable=False)
 
 
 class MCWhitelist(Base):

--- a/uqcsbot/models.py
+++ b/uqcsbot/models.py
@@ -34,7 +34,7 @@ class AOCRegistrations(Base):
         "discord_userid", BigInteger, primary_key=True, nullable=False
     )
     aoc_userid: Mapped[int] = mapped_column("aoc_userid", Integer, nullable=False)
-
+    year: Mapped[int] = mapped_column("year", Integer, nullable=False) # Try to remove this column from the database at some point
 
 class MCWhitelist(Base):
     __tablename__ = "mc_whitelisted"


### PR DESCRIPTION
This consists of two parts (that could have been separate PRs but are related).

Firstly, better error are now given session token expires. If the session token expires, the leaderboard page redirects to the advent home page (with a successful 200 response code) so the bot fails to read this as python. If we block redirects, we can detect this earlier and provide a better error message.

Secondly, AOC registrations did not persist between years. By removing the year in the registrations table, registrations will persist between years. Not that this will also require access to the database to remove this column. PLEASE DON'T MERGE until this is done. Once reviewed, I am happy to do this.