### PR TITLE
advent: increase interaction timeout and optimise

### DIFF
--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -1,6 +1,6 @@
 import io
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from random import choices
 from typing import Any, Callable, Dict, Iterable, List, Optional, Literal
 import requests
@@ -141,7 +141,7 @@ leaderboards_for_month: Dict[SortingMethod, str] = {
 
 class LeaderboardView(discord.ui.View):
     TRUNCATED_COUNT = 20
-    TIMEOUT = 180  # seconds
+    TIMEOUT = timedelta(hours=24).total_seconds()
 
     def __init__(
         self,

--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -212,7 +212,7 @@ class LeaderboardView(discord.ui.View):
         )
 
         leaderboard = self._build_leaderboard(self._visible_members)
-        scoreboard_image = render_leaderboard_to_image(leaderboard)
+        scoreboard_image = render_leaderboard_to_image(tuple(leaderboard))
         file = discord.File(io.BytesIO(scoreboard_image), self.basename + ".png")
         embed.set_image(url=f"attachment://{file.filename}")
 

--- a/uqcsbot/utils/advent_utils.py
+++ b/uqcsbot/utils/advent_utils.py
@@ -478,7 +478,7 @@ def render_leaderboard_to_image(leaderboard: Tuple[str | ColourFragment, ...]) -
 
 
 def build_leaderboard(
-    columns: List[LeaderboardColumn], members: Iterable[Member], day: Optional[Day]
+    columns: List[LeaderboardColumn], members: List[Member], day: Optional[Day]
 ):
     """
     Returns a leaderboard made up of fragments, with the given column configuration

--- a/uqcsbot/utils/advent_utils.py
+++ b/uqcsbot/utils/advent_utils.py
@@ -1,6 +1,7 @@
 from typing import (
     Any,
     DefaultDict,
+    Iterable,
     List,
     Literal,
     Dict,
@@ -418,7 +419,7 @@ def render_leaderboard_to_text(leaderboard: Leaderboard) -> str:
 
 
 def _isolate_leaderboard_layers(
-    leaderboard: Leaderboard,
+    leaderboard: Iterable[str | ColourFragment],
 ) -> Tuple[str, Dict[Colour, str]]:
     """
     Given a leaderboard made up of coloured fragments, split the
@@ -448,7 +449,7 @@ def _isolate_leaderboard_layers(
 
 
 @lru_cache(maxsize=16)
-def render_leaderboard_to_image(leaderboard: Leaderboard) -> bytes:
+def render_leaderboard_to_image(leaderboard: Tuple[str | ColourFragment, ...]) -> bytes:
     spaces, layers = _isolate_leaderboard_layers(leaderboard)
 
     # NOTE: font choice should support as wide a range of glyphs as possible,
@@ -477,7 +478,7 @@ def render_leaderboard_to_image(leaderboard: Leaderboard) -> bytes:
 
 
 def build_leaderboard(
-    columns: List[LeaderboardColumn], members: List[Member], day: Optional[Day]
+    columns: List[LeaderboardColumn], members: Iterable[Member], day: Optional[Day]
 ):
     """
     Returns a leaderboard made up of fragments, with the given column configuration


### PR DESCRIPTION
optimisation to cache image data when switching to/from full view. this is done by lru_cache, currently with a size of 16 (enough for 8 /leaderboard calls, with 2 image each)