### PR TITLE
advent: Add user-agent header to leaderboard requests

### DIFF
--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -356,6 +356,7 @@ class Advent(commands.Cog):
             response = requests.get(
                 LEADERBOARD_URL.format(year=year, code=code),
                 cookies={"session": self.session_id},
+                headers={"user-agent": "github.com/UQComputingSociety/uqcsbot-discord"},
                 allow_redirects=False,  # Will redirct to home page if session token is out of date
             )
         except RequestException as exception:


### PR DESCRIPTION
The AoC [automation guidelines](https://old.reddit.com/r/adventofcode/wiki/faqs/automation) specify that we should have a user-agent header on outgoing requests, so here is one.