### PR TITLE
Do not load minecraft cog

### DIFF
--- a/uqcsbot/__main__.py
+++ b/uqcsbot/__main__.py
@@ -57,7 +57,7 @@ async def main():
         "latex",
         "manage_cogs",
         "member_counter",
-        "minecraft",
+        # "minecraft",
         "morse",
         "past_exams",
         "phonetics",


### PR DESCRIPTION
Currently, the minecraft cog is loaded every time the bot restarts, despite the Minecraft server not being a thing for years. This single character change will prevent it from being loaded on restarts. The cog can still be loaded and unloaded using the `/managecogs action:load cog:minecraft` command. If a new Minecraft server is created in the future, I encourage whoever is responsible to remove the offending `#`.