### PR TITLE
Update yelling.py

### DIFF
--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -96,8 +96,12 @@ class Yelling(commands.Cog):
                     role = discord.utils.get(
                         self.bot.uqcs_server.roles, name="committee"
                     )
-                    await new.reply(
-                        role.mention
+                    if isinstance(role, discord.Role):
+                        ping = role.mention
+                    else:
+                        ping = "<@&813325414302875669>"
+                    await msg.reply(
+                        ping
                         + "! "
                         + new.author.mention
                         + " IS ABUSING THEIR DISCORD PRIVILEGES! NAUGHTY "
@@ -127,8 +131,12 @@ class Yelling(commands.Cog):
                     role = discord.utils.get(
                         self.bot.uqcs_server.roles, name="committee"
                     )
+                    if isinstance(role, discord.Role):
+                        ping = role.mention
+                    else:
+                        ping = "<@&813325414302875669>"
                     await msg.reply(
-                        role.mention
+                        ping
                         + "! "
                         + msg.author.mention
                         + " IS ABUSING THEIR DISCORD PRIVILEGES! NAUGHTY "

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -93,9 +93,12 @@ class Yelling(commands.Cog):
             if isinstance(new.author, discord.Member):
                 banned = await self.handle_bans(new.author)
                 if not banned:
-                    role = discord.utils.get(self.bot.uqcs_server.roles, name="committee")
+                    role = discord.utils.get(
+                        self.bot.uqcs_server.roles, name="committee"
+                    )
                     await new.reply(
-                        role.mention + "! "
+                        role.mention
+                        + "! "
                         + new.author.mention
                         + " IS ABUSING THEIR DISCORD PRIVILEGES! NAUGHTY "
                         + new.author.mention
@@ -121,9 +124,12 @@ class Yelling(commands.Cog):
             if isinstance(msg.author, discord.Member):
                 banned = await self.handle_bans(msg.author)
                 if not banned:
-                    role = discord.utils.get(self.bot.uqcs_server.roles, name="committee")
+                    role = discord.utils.get(
+                        self.bot.uqcs_server.roles, name="committee"
+                    )
                     await msg.reply(
-                        role.mention + "! "
+                        role.mention
+                        + "! "
                         + msg.author.mention
                         + " IS ABUSING THEIR DISCORD PRIVILEGES! NAUGHTY "
                         + msg.author.mention

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -100,7 +100,7 @@ class Yelling(commands.Cog):
                         ping = role.mention
                     else:
                         ping = "<@&813325414302875669>"
-                    await msg.reply(
+                    await new.reply(
                         ping
                         + "! "
                         + new.author.mention

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -93,8 +93,9 @@ class Yelling(commands.Cog):
             if isinstance(new.author, discord.Member):
                 banned = await self.handle_bans(new.author)
                 if not banned:
+                    role = discord.utils.get(self.bot.uqcs_server.roles, name="committee")
                     await new.reply(
-                        "<@&813325414302875669>! "
+                        role.mention + "! "
                         + new.author.mention
                         + " IS ABUSING THEIR DISCORD PRIVILEGES! NAUGHTY "
                         + new.author.mention
@@ -120,8 +121,9 @@ class Yelling(commands.Cog):
             if isinstance(msg.author, discord.Member):
                 banned = await self.handle_bans(msg.author)
                 if not banned:
+                    role = discord.utils.get(self.bot.uqcs_server.roles, name="committee")
                     await msg.reply(
-                        "<@&813325414302875669>! "
+                        role.mention + "! "
                         + msg.author.mention
                         + " IS ABUSING THEIR DISCORD PRIVILEGES! NAUGHTY "
                         + msg.author.mention

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -97,7 +97,7 @@ class Yelling(commands.Cog):
                         "<@&813325414302875669>! "
                         + new.author.mention
                         + " IS ABUSING THEIR DISCORD PRIVILEGES! NAUGHTY "
-                        + msg.author.mention
+                        + new.author.mention
                         + "!"
                     )
 

--- a/uqcsbot/yelling.py
+++ b/uqcsbot/yelling.py
@@ -146,7 +146,9 @@ class Yelling(commands.Cog):
         db_session.close()
 
         try:
-            await author.timeout(timedelta(seconds=(15 * 2**value)), reason="#yelling")
+            await author.timeout(
+                timedelta(seconds=(15 * 2**value)), reason="#yelling"
+            )
         except discord.Forbidden:
             return False
         return True
@@ -168,7 +170,9 @@ class Yelling(commands.Cog):
         db_session.close()
 
         try:
-            await author.timeout(timedelta(seconds=(15 * 2**value)), reason="#yelling")
+            await author.timeout(
+                timedelta(seconds=(15 * 2**value)), reason="#yelling"
+            )
         except discord.Forbidden:
             return False
         return True


### PR DESCRIPTION
The UQCS `#yelling` tradition dates back to May 2019, in the days of the UQCS Slack, and bot functionality was added in September that same year. It was carried over to Discord early in the migration process. Due to Discord permissions, however, some members cannot have a timeout applied by the bot. 

In April, May, and June of this year, there were nine members who triggered the yelling functionality of the bot ten or more times. Of these, four had some sort of role that exempted them from the time out; specifically, they were either committee members or subcommittee members. Given that such members make up a vast minority of UQCS members, this would indicate that such members would be wildly more likely to trigger the yelling functionality of the bot. Anecdotally, these members also seemed to me to be more likely to send multiple messages in a row that would trigger the yelling functionality.

I believe that the tradition works best when everybody participates, and are in on the joke, and as such, nobody should be immune from the yelling functionality. The timeout cannot be applied to these members, and rearranging roles to allow the timeout to be applied would cause more problems that it would solve. Instead, this PR will add an alternative "punishment", in the form of additional chastisement, to anybody who the bot fails to time out.

During a previous PR addressing the same issue via a different method, concerns were raised that occasionally, committee members would need to send serious messages in `#yelling`, and the method used in that PR would jeopardise this. Such a scenario seems rare enough that I cannot recall any instances, but nonetheless, it should be borne in mind. This PR will cause the bot to send two messages instead of one, so the structure of `#yelling` won't change. Should a committee member need to send serious messages, then the current process should suffice for if this PR is implemented. I would suspect the process would be to delete the bot's reply message to any serious messages sent, in which case the committee member would just need to delete two messages instead of one.