### PR TITLE
Holidays: Added UQCS Anniversary

### DIFF
--- a/uqcsbot/static/geek_holidays.csv
+++ b/uqcsbot/static/geek_holidays.csv
@@ -3,7 +3,9 @@
 10 Feb,Nerd History: Mario Kart 64 U.S. Release (1997),https://en.wikipedia.org/wiki/Mario_Kart
 12 Feb,Darwin Day,https://www.timeanddate.com/holidays/fun/darwin-day
 19 Feb,Nerd History: Nolan Bushnell receives a grant for Pong (1974),https://www.wired.com/story/inside-story-of-pong-excerpt/
+20 Feb,Anniversary of the Release of Python (1991),https://en.wikipedia.org/wiki/Python_(programming_language)
 22 Feb,World Thinking Day,https://en.wikipedia.org/wiki/World_Thinking_Day
+4 Mar,Anniversary of UQ Computing Society (2011),https://uqcs.org/
 10 Mar,Mario Day,https://www.daysoftheyear.com/days/mario-day/
 14 Mar,Pi Day (US),https://en.wikipedia.org/wiki/Pi_Day
 25 Mar,Tolkien reading day (the One Ring is destroyed),https://www.tolkiensociety.org/society/events/reading-day/
@@ -14,10 +16,10 @@
 2 May,Battle of Hogwarts Anniversary (1998),https://www.wizardingworld.com/features/battle-of-hogwarts-timeline
 4 May,Star Wars Day,https://www.starwars.com/star-wars-day
 18 May,International Museum Day,http://imd.icom.museum/
+23 May,Anniversary of the Releast of Java (1995),https://en.wikipedia.org/wiki/Java_(programming_language)
 24 May,Aviation Maintenance Technician Day,https://en.wikipedia.org/wiki/Aviation_Maintenance_Technician_Day
 25 May,Geek Pride Day,https://en.wikipedia.org/wiki/Geek_Pride_Day
 26 May,National Paper Aeroplane Day,https://nationaltoday.com/national-paper-airplane-day/
-6 Jun,Anniversary of the Release of Tetris,https://en.wikipedia.org/wiki/Tetris
 10 Jun,Ballpoint Pen Day,https://www.daysoftheyear.com/days/ball-point-pen-day/
 16 Jun,Bloomsday,https://en.wikipedia.org/wiki/Bloomsday
 28 Jun,Tau day,https://www.timeanddate.com/holidays/fun/tau-day


### PR DESCRIPTION
I figure we should celebrate the anniversary of UQCS. I've also added a few other dates and removed one. The justification is as follows:

- UQCS had their first meeting on the 4th of march 2011 as detailed [here](https://docs.google.com/document/d/1uls1RO6S7ytIstaXkBj9mZdA_mcHcOoz-xTsMoNUmZs/preview?tab=t.0). This aligns with the information from [the router](https://router.uqcs.org/1248071/episodes/9304380-the-history-of-uqcs-with-jackson-taylor-cameron-nick-madhav-and-james). I'm unsure if this should be considered as the "birthday" of UQCS, but it is my best selection of a date.
- Python 0.9.1 was publically released ( see [here](https://www.tuhs.org/Usenet/alt.sources/1991-February/001749.html))
- For Java, see [here](https://www.forbes.com/sites/oracle/2015/05/20/javas-20-years-of-innovation/)
- The exact date of tetris seems ambiguous (see [here](https://web.archive.org/web/20240717140506/https://www.timeextension.com/news/2024/06/anniversary-is-tetris-really-40-this-year)), so I removd this one.