### PR TITLE
AOC Fix announcement cron schedule and leaderboard displayed days

### DIFF
--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -995,7 +995,7 @@ The arguments for the command have a bit of nuance. They are as follow:
         interaction: discord.Interaction,
         prize: str,
         start: int = 1,
-        end: int = 25,
+        end: int = 12,
         number_of_winners: int = 1,
         weights: Literal["Stars", "Equal"] = "Equal",
         allow_repeat_winners: bool = False,
@@ -1098,7 +1098,7 @@ The arguments for the command have a bit of nuance. They are as follow:
                 winners_message += " and "
 
         await interaction.edit_original_response(
-            content=f"The results are in! Out of {number_of_potential_winners} potential participants, {winners_message} have recieved a prize from participating in Advent of Code: {prize}",
+            content=f"The results are in! Out of {number_of_potential_winners} potential participants, {winners_message} have received a prize from participating in Advent of Code: {prize}",
             allowed_mentions=discord.AllowedMentions(
                 everyone=False, users=True, roles=False
             ),

--- a/uqcsbot/advent.py
+++ b/uqcsbot/advent.py
@@ -301,7 +301,7 @@ class Advent(commands.Cog):
             trigger="cron",
             timezone="Australia/Brisbane",
             hour=15,
-            day="1-25",
+            day="1-12",
             month=12,
         )
         self.bot.schedule_task(
@@ -310,7 +310,7 @@ class Advent(commands.Cog):
             timezone="Australia/Brisbane",
             hour=14,
             minute=45,
-            day="1-25",
+            day="1-12",
             month=12,
         )
 


### PR DESCRIPTION
This PR changes the announcement for releasing Advent of Code puzzles to be posted only on the 1st through to the 12th.
It also updates the leaderboard command to limit the number of days displayed to the maximum for that year (sourced from the leaderboard API response), or to the provided number if a custom style is used.
Additionally, it gives an error to the user if they attempt to view a day that is not part of AOC that year.